### PR TITLE
Improve notification handling

### DIFF
--- a/OpenAssistant/Main/Extensions.swift
+++ b/OpenAssistant/Main/Extensions.swift
@@ -6,6 +6,9 @@ extension Notification.Name {
     static let assistantCreated = Notification.Name("assistantCreated")
     static let assistantUpdated = Notification.Name("assistantUpdated")
     static let assistantDeleted = Notification.Name("assistantDeleted")
+    static let vectorStoreCreated = Notification.Name("vectorStoreCreated")
+    static let vectorStoreUpdated = Notification.Name("vectorStoreUpdated")
+    static let vectorStoreDeleted = Notification.Name("vectorStoreDeleted")
 }
 
 // MARK: - View Extension for Keyboard Dismissal

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "OpenAssistant",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "OpenAssistant",
+            targets: ["OpenAssistant"])
+    ],
+    targets: [
+        .target(
+            name: "OpenAssistant",
+            path: "OpenAssistant"
+        )
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -7,14 +7,24 @@ let package = Package(
         .iOS(.v15)
     ],
     products: [
-        .library(
-            name: "OpenAssistant",
-            targets: ["OpenAssistant"])
+        .library(name: "OpenAssistant", targets: ["OpenAssistant"])
     ],
     targets: [
         .target(
             name: "OpenAssistant",
-            path: "OpenAssistant"
+            path: "OpenAssistant",
+            exclude: [
+                "Assets.xcassets",
+                "Preview Content",
+                "Debug.xcconfig",
+                "Release.xcconfig",
+                "Info.plist",
+                "File",
+                "cline_docs",
+                "PrivacyInfo.xcprivacy",
+                "Main/Utils.swift",
+                "MVVMs/Bases/CommonMethods.swift"
+            ]
         )
     ]
 )


### PR DESCRIPTION
## Summary
- prevent overlapping fetch requests with `isFetching`
- post vector store lifecycle notifications on the main thread
- emit notifications only from the ViewModel
- add Package.swift so `swift build` locates the manifest

## Testing
- `swift build` *(fails: multiple producers for object files)*

------
https://chatgpt.com/codex/tasks/task_b_685178114c488332ad7947c441f0c68d

## Summary by Sourcery

Prevent overlapping vector store fetches, centralize lifecycle notifications within the ViewModel, and add a Swift Package Manager manifest.

Bug Fixes:
- Prevent overlapping fetch requests in the ViewModel using an `isFetching` guard.

Enhancements:
- Centralize vector store lifecycle notifications within the ViewModel, posting them on the main thread and auto-refreshing stores upon notification.

Build:
- Add Package.swift manifest to enable `swift build` for the project.