### PR TITLE
Add token-based IAP system

### DIFF
--- a/OpenAssistant/MVVMs/Chat/ChatViewModel.swift
+++ b/OpenAssistant/MVVMs/Chat/ChatViewModel.swift
@@ -32,6 +32,7 @@ class ChatViewModel: BaseViewModel {
     @Published var stepCounter: Int = 0
     @Published var loadingState: LoadingState = .idle
     @Published var shouldFocusTextField: Bool = false  // Add state to control focus
+    @AppStorage("tokenBalance") private var tokenBalance: Int = 0
 
     // Expose the thread ID as a computed property
     var threadId: String? {
@@ -270,6 +271,10 @@ class ChatViewModel: BaseViewModel {
 
     func sendMessage() {
         guard let thread = thread, !inputText.isEmpty else { return }
+        guard tokenBalance > 0 else {
+            errorMessage = IdentifiableError(message: "Not enough tokens. Visit Credits to buy more.")
+            return
+        }
         let textToSend = inputText  // Capture text before clearing
         inputText = ""  // Clear input field immediately
 
@@ -305,6 +310,7 @@ class ChatViewModel: BaseViewModel {
                 self?.handleSendMessageResult(result)
             }
         }
+        tokenBalance -= 1
     }
 
     // Updated to accept content directly

--- a/OpenAssistant/Main/CreditsView.swift
+++ b/OpenAssistant/Main/CreditsView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct CreditsView: View {
+    @StateObject private var iap = IAPManager.shared
+    @AppStorage("tokenBalance") private var tokenBalance: Int = 0
+
+    var body: some View {
+        List {
+            Section(header: Text("Your Balance")) {
+                Text("\(tokenBalance) tokens")
+            }
+            Section(header: Text("Buy Tokens")) {
+                ForEach(iap.products) { product in
+                    Button(product.displayName) {
+                        Task { await iap.purchase(product) }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Credits")
+        .task { await iap.loadProducts() }
+        .onAppear { iap.startObservingTransactions() }
+    }
+}
+
+struct CreditsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            CreditsView()
+        }
+    }
+}

--- a/OpenAssistant/Main/OpenAssistantApp.swift
+++ b/OpenAssistant/Main/OpenAssistantApp.swift
@@ -47,5 +47,6 @@ struct OpenAssistantApp: App {
     private func handleOnAppear() {
         assistantManagerViewModel.fetchAssistants()
         showSettingsView = apiKey.isEmpty
+        IAPManager.shared.startObservingTransactions()
     }
 }

--- a/OpenAssistant/Main/SettingsView.swift
+++ b/OpenAssistant/Main/SettingsView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 
 struct SettingsView: View {
     @AppStorage("OpenAI_API_Key") private var apiKey: String = ""
+    @AppStorage("tokenBalance") private var tokenBalance: Int = 0
     // Use AppearanceMode enum for storing preference
     @AppStorage("appearanceMode") private var appearanceMode: AppearanceMode.RawValue =
         AppearanceMode.system.rawValue
@@ -21,6 +22,7 @@ struct SettingsView: View {
         Form {
             apiKeySection  // Section for API Key
             appearanceSection  // Section for Appearance
+            creditsSection
         }
         .navigationBarTitle("Settings", displayMode: .inline)
         // Apply preferred color scheme based on selection using the global enum's helper
@@ -78,6 +80,18 @@ struct SettingsView: View {
             }
             // Use MenuPickerStyle for dropdown appearance
             .pickerStyle(MenuPickerStyle())
+        }
+    }
+
+    private var creditsSection: some View {
+        Section(header: Label("Credits", systemImage: "cart")) {
+            NavigationLink(destination: CreditsView()) {
+                HStack {
+                    Text("Balance")
+                    Spacer()
+                    Text("\(tokenBalance)")
+                }
+            }
         }
     }
 

--- a/OpenAssistant/Store/IAPManager.swift
+++ b/OpenAssistant/Store/IAPManager.swift
@@ -1,0 +1,65 @@
+import Foundation
+import StoreKit
+import SwiftUI
+
+@MainActor
+final class IAPManager: ObservableObject {
+    static let shared = IAPManager()
+
+    @Published private(set) var products: [Product] = []
+    @AppStorage("tokenBalance") private var tokenBalance: Int = 0
+
+    private init() {}
+
+    func loadProducts() async {
+        do {
+            let ids: [String] = ["TokenPackSmall", "TokenPackLarge"]
+            products = try await Product.products(for: ids)
+        } catch {
+            print("IAPManager: Failed loading products - \(error)")
+        }
+    }
+
+    func startObservingTransactions() {
+        Task.detached { [weak self] in
+            for await result in Transaction.updates {
+                await self?.handle(transactionResult: result)
+            }
+        }
+    }
+
+    func purchase(_ product: Product) async {
+        do {
+            let result = try await product.purchase()
+            await handle(transactionResult: result)
+        } catch {
+            print("IAPManager: Purchase failed - \(error.localizedDescription)")
+        }
+    }
+
+    private func handle(transactionResult: Product.PurchaseResult) async {
+        switch transactionResult {
+        case .success(let verification):
+            do {
+                let transaction = try verification.payloadValue
+                await transaction.finish()
+                await grantTokens(for: transaction.productID)
+            } catch {
+                print("IAPManager: Transaction verification failed - \(error)")
+            }
+        default:
+            break
+        }
+    }
+
+    private func grantTokens(for productID: String) async {
+        switch productID {
+        case "TokenPackSmall":
+            tokenBalance += 1000
+        case "TokenPackLarge":
+            tokenBalance += 5000
+        default:
+            break
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `IAPManager` to load StoreKit products, purchase tokens and grant balance
- show balance and purchase options in new `CreditsView`
- expose credits via Settings screen
- start observing transactions on app launch
- deduct one token per sent chat message

## Testing
- `swift build` *(fails: no such module 'Combine')*

------
https://chatgpt.com/codex/tasks/task_b_685ac839344083328921a48c976e858c

## Summary by Sourcery

Introduce a token-based in-app purchase system using StoreKit and integrate it throughout the app.

New Features:
- Add IAPManager singleton to load products, handle purchases, and observe transactions
- Create CreditsView to display current token balance and purchase options
- Expose token balance in Settings and on app launch start observing transactions
- Enforce token requirement by deducting one token per sent chat message and showing an error when balance is insufficient